### PR TITLE
iOS LockSquare resetAspectRatioEnabled option

### DIFF
--- a/src/imagecropper.ios.ts
+++ b/src/imagecropper.ios.ts
@@ -108,6 +108,7 @@ export class ImageCropper {
           viewController.aspectRatioPreset = TOCropViewControllerAspectRatioPreset.PresetSquare;
           viewController.aspectRatioLockEnabled = true; // The crop box is locked to the aspect ratio and can't be resized away from it
           viewController.aspectRatioPickerButtonHidden = true;
+          viewController.resetAspectRatioEnabled = false;
         }
         page.presentViewControllerAnimatedCompletion(viewController, true, function () {
           if (_options) {


### PR DESCRIPTION
When lockSquare is enabled, clicking the reset button no longer resets the aspect ratio.