### PR TITLE
Fix multidex on Android

### DIFF
--- a/src/platforms/android/include.gradle
+++ b/src/platforms/android/include.gradle
@@ -20,7 +20,7 @@ dependencies {
   configurations.all {
       resolutionStrategy.eachDependency { details ->
           def requested = details.requested
-          if (requested.group == 'com.android.support' && requested.name != 'multidex') {
+          if (requested.group == 'com.android.support' && requested.name.startsWith('multidex') == false) {
               // com.android.support major version should match buildToolsVersion
               details.useVersion "$supportVersion"
           }


### PR DESCRIPTION
This should fix #30.

The script is currently setting every package inside `com.android.support` to the SDK version number. Some of them, like the Multidex ones, are on a different version number, but #28 only partially addressed this: there are more Multidex packages whose version numbers differ from the SDK one, e.g. `multidex-instrumentation`, so I made a slight change to the way the script looks for them.